### PR TITLE
Fix penalty assignment when offense is set wrong

### DIFF
--- a/reco/2003/2003_20031102_CIN_at_ARI.json
+++ b/reco/2003/2003_20031102_CIN_at_ARI.json
@@ -1,7 +1,7 @@
 {
   "_version": {
-    "parser": "c734f6825dca35468f303f225fff1fd826be39d5",
-    "raw": "59ba588bd603c7d963a62c7bfb7273bf4f6f9ba3"
+    "parser": "7be045e1e1d2ef9984d86313a1432bb849e64c9a",
+    "raw": "b17907f7b9f2d692a0628a447e7883e3429b81ac"
   },
   "away team": "CIN",
   "betting": {
@@ -71,7 +71,7 @@
             "accepted": true,
             "name": "False Start",
             "offender": "Mike Goff",
-            "team": null,
+            "team": "away",
             "yards": 5
           }
         ]
@@ -100,7 +100,7 @@
             "accepted": true,
             "name": "False Start",
             "offender": "Mike Goff",
-            "team": null,
+            "team": "away",
             "yards": 5
           }
         ]


### PR DESCRIPTION
Data updated with the fix from
Ten-Point-Touchdowns/Football-Data-Converter#14.